### PR TITLE
Bump go-skynet/local-ai from v2.24.2 to v2.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # From https://github.com/mudler/LocalAI/blob/master/Dockerfile
-FROM quay.io/go-skynet/local-ai:v2.24.2-aio-cpu
+FROM quay.io/go-skynet/local-ai:v2.26.0-aio-cpu
 
 COPY --chmod=775 start.sh /start.sh
 

--- a/Dockerfile.cuda12
+++ b/Dockerfile.cuda12
@@ -1,5 +1,5 @@
 # From https://github.com/mudler/LocalAI/blob/master/Dockerfile
-FROM quay.io/go-skynet/local-ai:v2.24.2-aio-gpu-nvidia-cuda-12
+FROM quay.io/go-skynet/local-ai:v2.26.0-aio-gpu-nvidia-cuda-12
 
 COPY --chmod=775 start.sh /start.sh
 


### PR DESCRIPTION
Update the version of go-skynet/local-ai from v2.24.2 to v2.26.0 in Dockerfile and Dockerfile.cuda12.

* Update the `FROM` line in `Dockerfile` to reference `quay.io/go-skynet/local-ai:v2.26.0-aio-cpu`.
* Update the `FROM` line in `Dockerfile.cuda12` to reference `quay.io/go-skynet/local-ai:v2.26.0-aio-gpu-nvidia-cuda-12`.

